### PR TITLE
Use keyspace/table name only for filename in RangeAwareSSTableWriter

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/SSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableMultiWriter.java
@@ -47,11 +47,6 @@ public interface SSTableMultiWriter extends Transactional
     long getFilePointer();
     UUID getCfId();
 
-    default String getWriterId()
-    {
-        return getFilename();
-    }
-
     static void abortOrDie(SSTableMultiWriter writer)
     {
         Throwables.maybeFail(writer.abort(null));

--- a/src/java/org/apache/cassandra/io/sstable/format/RangeAwareSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/RangeAwareSSTableWriter.java
@@ -49,7 +49,6 @@ public class RangeAwareSSTableWriter implements SSTableMultiWriter
     private final List<SSTableMultiWriter> finishedWriters = new ArrayList<>();
     private final List<SSTableReader> finishedReaders = new ArrayList<>();
     private SSTableMultiWriter currentWriter = null;
-    private final UUID uniqueId = UUID.randomUUID();
 
     public RangeAwareSSTableWriter(ColumnFamilyStore cfs, long estimatedKeys, long repairedAt, SSTableFormat.Type format, int sstableLevel, long totalSize, LifecycleTransaction txn, SerializationHeader.Component header) throws IOException
     {
@@ -163,12 +162,6 @@ public class RangeAwareSSTableWriter implements SSTableMultiWriter
     public UUID getCfId()
     {
         return currentWriter.getCfId();
-    }
-
-    @Override
-    public String getWriterId()
-    {
-        return uniqueId.toString();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/RangeAwareSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/RangeAwareSSTableWriter.java
@@ -147,9 +147,7 @@ public class RangeAwareSSTableWriter implements SSTableMultiWriter
 
     public String getFilename()
     {
-        if (currentWriter != null)
-            return currentWriter.getFilename();
-        return "null";
+        return String.join("/", cfs.keyspace.getName(), cfs.getTableName());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/streaming/ProgressInfo.java
+++ b/src/java/org/apache/cassandra/streaming/ProgressInfo.java
@@ -48,7 +48,6 @@ public class ProgressInfo implements Serializable
         }
     }
 
-    public final String id;
     public final InetAddress peer;
     public final int sessionIndex;
     public final String fileName;
@@ -56,11 +55,10 @@ public class ProgressInfo implements Serializable
     public final long currentBytes;
     public final long totalBytes;
 
-    public ProgressInfo(String id, InetAddress peer, int sessionIndex, String fileName, Direction direction, long currentBytes, long totalBytes)
+    public ProgressInfo(InetAddress peer, int sessionIndex, String fileName, Direction direction, long currentBytes, long totalBytes)
     {
         assert totalBytes > 0;
 
-        this.id = id;
         this.peer = peer;
         this.sessionIndex = sessionIndex;
         this.fileName = fileName;

--- a/src/java/org/apache/cassandra/streaming/SessionInfo.java
+++ b/src/java/org/apache/cassandra/streaming/SessionInfo.java
@@ -78,7 +78,7 @@ public final class SessionInfo implements Serializable
 
         Map<String, ProgressInfo> currentFiles = newProgress.direction == ProgressInfo.Direction.IN
                                                     ? receivingFiles : sendingFiles;
-        currentFiles.put(newProgress.id, newProgress);
+        currentFiles.put(newProgress.fileName, newProgress);
     }
 
     public Collection<ProgressInfo> getReceivingFiles()

--- a/src/java/org/apache/cassandra/streaming/StreamReader.java
+++ b/src/java/org/apache/cassandra/streaming/StreamReader.java
@@ -106,7 +106,7 @@ public class StreamReader
             {
                 writePartition(deserializer, writer);
                 // TODO move this to BytesReadTracker
-                session.progress(writer.getWriterId(), writer.getFilename(), ProgressInfo.Direction.IN, in.getBytesRead(), totalSize);
+                session.progress(writer.getFilename(), ProgressInfo.Direction.IN, in.getBytesRead(), totalSize);
             }
             return writer;
         }

--- a/src/java/org/apache/cassandra/streaming/StreamSession.java
+++ b/src/java/org/apache/cassandra/streaming/StreamSession.java
@@ -584,9 +584,9 @@ public class StreamSession implements IEndpointStateChangeSubscriber
         receivers.get(message.header.cfId).received(message.sstable);
     }
 
-    public void progress(String id, String filename, ProgressInfo.Direction direction, long bytes, long total)
+    public void progress(String filename, ProgressInfo.Direction direction, long bytes, long total)
     {
-        ProgressInfo progress = new ProgressInfo(id, peer, index, filename, direction, bytes, total);
+        ProgressInfo progress = new ProgressInfo(peer, index, filename, direction, bytes, total);
         streamResult.handleProgress(progress);
     }
 

--- a/src/java/org/apache/cassandra/streaming/StreamWriter.java
+++ b/src/java/org/apache/cassandra/streaming/StreamWriter.java
@@ -102,8 +102,7 @@ public class StreamWriter
                     long lastBytesRead = write(file, validator, readOffset, length, bytesRead);
                     bytesRead += lastBytesRead;
                     progress += (lastBytesRead - readOffset);
-                    String filename = sstable.descriptor.filenameFor(Component.DATA);
-                    session.progress(filename, filename, ProgressInfo.Direction.OUT, progress, totalSize);
+                    session.progress(sstable.descriptor.filenameFor(Component.DATA), ProgressInfo.Direction.OUT, progress, totalSize);
                     readOffset = 0;
                 }
 

--- a/src/java/org/apache/cassandra/streaming/compress/CompressedStreamReader.java
+++ b/src/java/org/apache/cassandra/streaming/compress/CompressedStreamReader.java
@@ -96,7 +96,7 @@ public class CompressedStreamReader extends StreamReader
                 {
                     writePartition(deserializer, writer);
                     // when compressed, report total bytes of compressed chunks read since remoteFile.size is the sum of chunks transferred
-                    session.progress(writer.getWriterId(), writer.getFilename(), ProgressInfo.Direction.IN, cis.getTotalCompressedBytesRead(), totalSize);
+                    session.progress(writer.getFilename(), ProgressInfo.Direction.IN, cis.getTotalCompressedBytesRead(), totalSize);
                 }
             }
             return writer;

--- a/src/java/org/apache/cassandra/streaming/compress/CompressedStreamWriter.java
+++ b/src/java/org/apache/cassandra/streaming/compress/CompressedStreamWriter.java
@@ -76,8 +76,7 @@ public class CompressedStreamWriter extends StreamWriter
                     long lastWrite = out.applyToChannel((wbc) -> fc.transferTo(section.left + bytesTransferredFinal, toTransfer, wbc));
                     bytesTransferred += lastWrite;
                     progress += lastWrite;
-                    String filename = sstable.descriptor.filenameFor(Component.DATA);
-                    session.progress(filename, filename, ProgressInfo.Direction.OUT, progress, totalSize);
+                    session.progress(sstable.descriptor.filenameFor(Component.DATA), ProgressInfo.Direction.OUT, progress, totalSize);
                 }
             }
         }

--- a/src/java/org/apache/cassandra/streaming/management/ProgressInfoCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/ProgressInfoCompositeData.java
@@ -36,24 +36,21 @@ public class ProgressInfoCompositeData
                                                             "fileName",
                                                             "direction",
                                                             "currentBytes",
-                                                            "totalBytes",
-                                                            "id"};
+                                                            "totalBytes"};
     private static final String[] ITEM_DESCS = new String[]{"String representation of Plan ID",
                                                             "Session peer",
                                                             "Index of session",
                                                             "Name of the file",
                                                             "Direction('IN' or 'OUT')",
                                                             "Current bytes transferred",
-                                                            "Total bytes to transfer",
-                                                            "Identifier"};
+                                                            "Total bytes to transfer"};
     private static final OpenType<?>[] ITEM_TYPES = new OpenType[]{SimpleType.STRING,
                                                                    SimpleType.STRING,
                                                                    SimpleType.INTEGER,
                                                                    SimpleType.STRING,
                                                                    SimpleType.STRING,
                                                                    SimpleType.LONG,
-                                                                   SimpleType.LONG,
-                                                                   SimpleType.STRING};
+                                                                   SimpleType.LONG};
 
     public static final CompositeType COMPOSITE_TYPE;
     static  {
@@ -81,7 +78,6 @@ public class ProgressInfoCompositeData
         valueMap.put(ITEM_NAMES[4], progressInfo.direction.name());
         valueMap.put(ITEM_NAMES[5], progressInfo.currentBytes);
         valueMap.put(ITEM_NAMES[6], progressInfo.totalBytes);
-        valueMap.put(ITEM_NAMES[7], progressInfo.id);
         try
         {
             return new CompositeDataSupport(COMPOSITE_TYPE, valueMap);
@@ -97,8 +93,7 @@ public class ProgressInfoCompositeData
         Object[] values = cd.getAll(ITEM_NAMES);
         try
         {
-            return new ProgressInfo((String) values[7],
-                                    InetAddress.getByName((String) values[1]),
+            return new ProgressInfo(InetAddress.getByName((String) values[1]),
                                     (int) values[2],
                                     (String) values[3],
                                     ProgressInfo.Direction.valueOf((String)values[4]),

--- a/test/unit/org/apache/cassandra/streaming/SessionInfoTest.java
+++ b/test/unit/org/apache/cassandra/streaming/SessionInfoTest.java
@@ -56,15 +56,14 @@ public class SessionInfoTest
         assert info.getTotalFilesReceived() == 0;
         assert info.getTotalFilesSent() == 0;
 
-        UUID id = UUID.randomUUID();
         // receive in progress
-        info.updateProgress(new ProgressInfo(id.toString(), local, 0, "test.txt", ProgressInfo.Direction.IN, 50, 100));
+        info.updateProgress(new ProgressInfo(local, 0, "test.txt", ProgressInfo.Direction.IN, 50, 100));
         // still in progress, but not completed yet
         assert info.getTotalSizeReceived() == 50;
         assert info.getTotalSizeSent() == 0;
         assert info.getTotalFilesReceived() == 0;
         assert info.getTotalFilesSent() == 0;
-        info.updateProgress(new ProgressInfo(id.toString(), local, 0, "test.txt", ProgressInfo.Direction.IN, 100, 100));
+        info.updateProgress(new ProgressInfo(local, 0, "test.txt", ProgressInfo.Direction.IN, 100, 100));
         // 1 file should be completed
         assert info.getTotalSizeReceived() == 100;
         assert info.getTotalSizeSent() == 0;


### PR DESCRIPTION
This is my suggestion for CASSANDRA-6696.
